### PR TITLE
Invalidate attendees cache on new purchase

### DIFF
--- a/addons/payment-blackhole.php
+++ b/addons/payment-blackhole.php
@@ -66,6 +66,7 @@ class CampTix_Payment_Method_Blackhole extends CampTix_Payment_Method {
 		// Process $order and do something.
 		$order = $this->get_order( $payment_token );
 		do_action( 'camptix_before_payment', $payment_token );
+		update_option( 'camptix_last_purchase_time', time() );
 
 		$payment_data = array(
 			'transaction_id' => 'tix-blackhole-' . md5( sprintf( 'tix-blackhole-%s-%s-%s', print_r( $order, true ), time(), rand( 1, 9999 ) ) ),

--- a/addons/shortcodes.php
+++ b/addons/shortcodes.php
@@ -45,8 +45,12 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 
 		$start = microtime(true);
 		$transient_key = md5( 'tix-attendees' . print_r( $atts, true ) );
-		if ( false !== ( $cached = get_transient( $transient_key ) ) )
-			return $cached;
+		if ( false !== ( $cached = get_transient( $transient_key ) ) ) {
+			if ( ! is_array( $cached ) )
+				return $cached;
+			elseif ( $cached['time'] > get_option( 'camptix_last_purchase_time', 0 ) )
+				return $cached['content'];
+		}
 
 		// Cache for a month if archived or less if active.
 		$cache_time = ( $camptix_options['archived'] ) ? 60 * 60 * 24 * 30 : 60 * 60;
@@ -135,7 +139,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 		wp_reset_postdata();
 		$content = ob_get_contents();
 		ob_end_clean();
-		set_transient( $transient_key, $content, $cache_time );
+		set_transient( $transient_key, array( 'content' => $content, 'time' => time() ), $cache_time );
 		return $content;
 	}
 


### PR DESCRIPTION
- Add a new option 'camptix_last_purchase_time'
- Check the time attendees were last cached, if it was before the last purchase then regenerate
- Cache attendees data in an array to store the time the cache was generated
