### PR TITLE
Use full opening PHP tag

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -2811,7 +2811,7 @@ class CampTix_Plugin {
 			<?php endif; ?>
 		</div>
 		<div class="clear"></div>
-		<?
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
Using short PHP open tags doesn't work on php installations with short_open_tag disabled.
