### PR TITLE
Set the quantity to 1 for single ticket

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -3965,7 +3965,7 @@ class CampTix_Plugin {
 							$discounted = '';
 
 							$max = min( $ticket->tix_remaining, 10 );
-							$selected = 0;
+							$selected = 1 == count( $this->tickets )? 1 : 0;
 							if ( isset( $this->tickets_selected[$ticket->ID] ) )
 								$selected = intval( $this->tickets_selected[$ticket->ID] );
 


### PR DESCRIPTION
If we have only once ticket type and the user
visits the tickets form, the 0 by default is
off-putting.

Instead, if there's only one ticket type, we
default the quantity to 1. This way the user can
just click Register and we will do the expected
thing. No choice needed.
