### PR TITLE
`register_addon` return value fix

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -6710,6 +6710,7 @@ class CampTix_Plugin {
 		}
 
 		$this->addons[] = $classname;
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
`register_addon` would not return anything (`null`) when an addon was being successfully registered. Added a `true` return value.
