### PR TITLE
`addons_loaded` correct append variable

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -6666,7 +6666,7 @@ class CampTix_Plugin {
 		do_action( 'camptix_load_addons' );
 		foreach ( $this->addons as $classname )
 			if ( class_exists( $classname ) )
-				$addons_loaded[] = new $classname;
+				$this->addons_loaded[] = new $classname;
 	}
 
 	/**


### PR DESCRIPTION
`addons_loaded` must be prefixed with `$this`, otherwise loaded addons are inacessible via `$camptix->loaded_addons`, which is unexpected.
