### PR TITLE
Urlencode reservation ids

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -4296,8 +4296,8 @@ class CampTix_Plugin {
 			$this->order['coupon'] = sanitize_text_field( $_REQUEST['tix_coupon'] );
 
 		if ( isset( $_REQUEST['tix_reservation_id'], $_REQUEST['tix_reservation_token'] ) ) {
-			$this->order['reservation_id'] = sanitize_text_field( $_REQUEST['tix_reservation_id'] );
-			$this->order['reservation_token'] = sanitize_text_field( $_REQUEST['tix_reservation_token'] );
+			$this->order['reservation_id'] = $_REQUEST['tix_reservation_id'];
+			$this->order['reservation_token'] = $_REQUEST['tix_reservation_token'];
 		}
 
 		// Check whether this is a valid order.


### PR DESCRIPTION
Currently, if a reservation name contains special characters for a URL,
the reservation URL won't work and we will get "Sorry, but the
reservation you are trying to use seems to be invalid or expired."

That's because sanitize_title_with_dashes urlencodes the data,
but all the request variables are automatically decoded and when we
compare them they don't match.
