### PR TITLE
Add an action and filter in to affect the tools menu tabs and pages.

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -1953,6 +1953,8 @@ class CampTix_Plugin {
 					$this->menu_tools_notify();
 				elseif ( $section == 'refund' && ! $this->options['archived'] )
 					$this->menu_tools_refund();
+				else
+					do_action( 'camptix_menu_tools_' . $section );
 			?>
 		</div>
 		<?php
@@ -1974,12 +1976,12 @@ class CampTix_Plugin {
 	 */
 	function menu_tools_tabs() {
 		$current_section = $this->get_tools_section();
-		$sections = array(
+		$sections = apply_filters( 'camptix_menu_tools_tabs', array(
 			'summarize' => __( 'Summarize', 'camptix' ),
 			'revenue' => __( 'Revenue', 'camptix' ),
 			'export' => __( 'Export', 'camptix' ),
 			'notify' => __( 'Notify', 'camptix' ),
-		);
+		) );
 
 		if ( current_user_can( $this->caps['refund_all'] ) && ! $this->options['archived'] && $this->options['refund_all_enabled'] )
 			$sections['refund'] = __( 'Refund', 'camptix' );


### PR DESCRIPTION
This is relatively self explanatory. Basically, the filter and actions I'm suggesting would allow developers to add tabs to the tools page. This is very useful for writing extensions that do not warrant their own options page.
