### PR TITLE
Adding post types to 'At a Glance' dashboard widget

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -272,6 +272,11 @@ label.tix-yes-no {
 	background-size: 196px 168px;
 }
 
+#dashboard_right_now a.tix_attendee-count:before,
+#dashboard_right_now span.tix_attendee-count:before {
+  content: "\f307";
+}
+
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5) {
 	#icon-edit.icon32-posts-tix_ticket {
 		background-size: 98px 84px;

--- a/camptix.php
+++ b/camptix.php
@@ -6957,7 +6957,7 @@ class CampTix_Plugin {
 	 * @return array         Modified items
 	 */
 	public function glance_items( $items = array() ) {
-		$post_types = apply_filters( 'camptix_glance_items', array( 'tix_attendee' ) );
+		$post_types = apply_filters( 'camptix_glance_items', array( 'tix_attendee', 'tix_ticket' ) );
 
 	    foreach( $post_types as $type ) {
 


### PR DESCRIPTION
- Adds the `tix_attendee` and `tix_ticket` post types to 'At a Glance' dashboard widget
- Adds CSS to display appropriate icon for post type
- Adds conditional to load `admin.css` on the dashboard page