### PR TITLE
fixes tickets_excess error flag check in form_attendee_info()

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -4727,7 +4727,7 @@ class CampTix_Plugin {
 		if ( isset( $this->error_flags['no_tickets_selected'], $_GET['tix_action'] ) && 'checkout' == $_GET['tix_action'] )
 			return $this->form_start();
 
-		if ( isset( $this->error_flags['tickets_excess'], $_GET['action'] ) )
+		if ( isset( $this->error_flags['tickets_excess'], $_GET['tix_action'] ) )
 			if ( 'attendee_info' == $_GET['tix_action'] )
 				$this->notice( __( 'It looks like you have chosen more tickets than we have left! We have stripped the extra ones.', 'camptix' ) );
 			elseif ( 'checkout' == $_GET['tix_action'] )


### PR DESCRIPTION
Typo fix that caused the tickets_excess error flag to never be caught.

prior to this, setting the tickets_excess error flag inside form_checkout() and then returning to form_attendee_info() would not actually be caught in form_attendee_info(). Instead the 'no_receipt_email' error flag is caught... 
