### PR TITLE
camptix_attendees shortcode: add option not to display duplicates

### DIFF
--- a/addons/shortcodes.php
+++ b/addons/shortcodes.php
@@ -140,13 +140,18 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 							),
 							$query_args
 						), $attr );
-						$attendees = get_posts( $attendee_args );
+						$attendees_raw = get_posts( $attendee_args );
 
-						if ( ! is_array( $attendees ) || count( $attendees ) < 1 )
+						if ( ! is_array( $attendees_raw ) || count( $attendees_raw ) < 1 )
 							break; // life saver!
 
 						// Disable object cache for prepared metadata.
-						$camptix->filter_post_meta = $camptix->prepare_metadata_for( $attendees );
+						$camptix->filter_post_meta = $camptix->prepare_metadata_for( $attendees_raw );
+
+						foreach ( $attendees_raw as $attendee ) {
+							$email = get_post_meta( $attendee, 'tix_email', true );
+							$attendees[$email] = $attendee;
+						}
 
 						foreach ( $attendees as $attendee_id ) {
 							$attendee_answers = (array) get_post_meta( $attendee_id, 'tix_questions', true );


### PR DESCRIPTION
Adds a loop that builds $attendees using email addresses as keys to prevent duplicates. Fixes #106