### PR TITLE
Hide the overlapping "Attended" column title in mobile views

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -312,6 +312,10 @@ body.post-type-tix_attendee table.posts td.attended div.spinner {
 	.fixed .column-tix_order_total {
 		display: none;
 	}
+
+	body.post-type-tix_attendee table.posts.fixed .column-attended::before {
+		content: "";
+	}
 }
 
 @media screen and ( max-width: 535px ) {


### PR DESCRIPTION
In the mobile view (<782px) of the attendee list, the Attended button is overlapped by a "Attended" label which comes from the list table. Although I'm sure the label serves a purpose, it causes problems accessing the button (and just looks ugly.)

See https://cloudup.com/caiDk82n2au for a before and after.