### PR TITLE
Remove unused variable `$locale`

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -1888,7 +1888,6 @@ class CampTix_Plugin {
 	function append_currency( $price, $nbsp = true, $currency_key = false ) {
 		$currencies = $this->get_currencies();
 		$currency = $currencies[ $this->options['currency'] ];
-		$locale = $currency['locale'];
 		if ( $currency_key )
 			$currency = $currencies[ $currency_key ];
 


### PR DESCRIPTION
As mentioned in #147 this is throwing a PHP notice, and the proper check is done a few lines ahead:

`
if ( isset( $currency['locale'] ) ) {
    setlocale( LC_MONETARY, $currency['locale'] );
}
`

It doesn't seem necessary to keep that variable.

I thought removing `$locale` was cleaner than performing the check while assigning the value (`$locale = ( isset( $currency['locale'] ) ) ? $currency['locale'] : null;`) and then using the variable. Please let me know if you prefer this last option.