### PR TITLE
Attendees shortcode: Lazy load attendee avatars

### DIFF
--- a/addons/shortcodes.php
+++ b/addons/shortcodes.php
@@ -141,7 +141,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 						$attendee_args = apply_filters( 'camptix_attendees_shortcode_query_args', array_merge(
 							array(
 								'post_type'      => 'tix_attendee',
-								'posts_per_page' => 50,
+								'posts_per_page' => 200,
 								'post_status'    => array( 'publish', 'pending' ),
 								'paged'          => $paged,
 								'order'          => $attr['order'],
@@ -183,12 +183,8 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 							$first = get_post_meta( $attendee_id, 'tix_first_name', true );
 							$last = get_post_meta( $attendee_id, 'tix_last_name', true );
 
-							if ( $paged > 1 ) {
-								// Use avatar placeholders for subsequent batches of attendees
-								echo $this->get_avatar_placeholder( get_post_meta( $attendee_id, 'tix_email', true ) );
-							} else {
-								echo get_avatar( get_post_meta( $attendee_id, 'tix_email', true ) );
-							}
+							// Avatar placeholders
+							echo $this->get_avatar_placeholder( get_post_meta( $attendee_id, 'tix_email', true ) );
 
 							// Only print the JS template once.
 							if ( ! has_action( 'wp_print_footer_scripts', array( $this, 'avatar_js_template' ) ) ) {

--- a/addons/shortcodes.php
+++ b/addons/shortcodes.php
@@ -238,7 +238,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 	 * Generate an avatar placeholder element with a data attribute that contains
 	 * the Gravatar hash so the real avatar can be loaded asynchronously.
 	 *
-	 * @param $id_or_email
+	 * @param string $id_or_email
 	 *
 	 * @return string
 	 */
@@ -247,7 +247,14 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 		$size = 96;
 
 		return sprintf(
-			'<div class="avatar avatar-placeholder" data-url="%s" data-url2x="%s" data-size="%s" data-alt="%s" data-appear-top-offset="500"></div>',
+			'<div 
+                class="avatar avatar-placeholder" 
+                data-url="%s" 
+                data-url2x="%s" 
+                data-size="%s" 
+                data-alt="%s" 
+                data-appear-top-offset="500"
+                ></div>',
 			get_avatar_url( $id_or_email ),
 			get_avatar_url( $id_or_email, array( 'size' => $size * 2  ) ),
 			$size,
@@ -261,7 +268,14 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 	public function avatar_js_template() {
 		?>
 		<script type="text/html" id="tmpl-tix-attendee-avatar">
-			<img alt="{{ data.alt }}" src="{{ data.url }}" srcset="{{ data.url2x }} 2x" class="avatar avatar-{{ data.size }} photo" height="{{ data.size }}" width="{{ data.size }}">
+			<img
+                    alt="{{ data.alt }}"
+                    src="{{ data.url }}"
+                    srcset="{{ data.url2x }} 2x"
+                    class="avatar avatar-{{ data.size }} photo"
+                    height="{{ data.size }}"
+                    width="{{ data.size }}"
+            >
 		</script>
 	<?php
 	}

--- a/camptix.css
+++ b/camptix.css
@@ -81,6 +81,10 @@ body.admin-bar #tix {
 	height: 50px;
 }
 
+#tix-attendees .avatar-placeholder {
+	/*color: #eee;*/ /* Change this to change the color of the loading spinner */
+}
+
 #tix-attendees .tix-field {
 	display: block;
 	margin-left: 70px;

--- a/camptix.css
+++ b/camptix.css
@@ -81,10 +81,6 @@ body.admin-bar #tix {
 	height: 50px;
 }
 
-#tix-attendees .avatar-placeholder {
-	/*color: #eee;*/ /* Change this to change the color of the loading spinner */
-}
-
 #tix-attendees .tix-field {
 	display: block;
 	margin-left: 70px;

--- a/camptix.js
+++ b/camptix.js
@@ -179,7 +179,7 @@ var docCookies={getItem:function(e){return decodeURIComponent(document.cookie.re
 		},
 
 		init: function() {
-			if ('undefined' == typeof $.fn.appear) {
+			if ('undefined' == typeof $.fn.appear || lazyLoad.cache.$attendees.length < 1) {
 				return;
 			}
 
@@ -187,7 +187,7 @@ var docCookies={getItem:function(e){return decodeURIComponent(document.cookie.re
 
 			lazyLoad.cache.$placeholders = lazyLoad.cache.$attendees.find('.avatar-placeholder');
 
-			lazyLoad.cache.$placeholders.appear();
+			lazyLoad.cache.$placeholders.appear({ interval: 500 });
 
 			lazyLoad.cache.$placeholders.one('appear', function(event) {
 				var $placeholder = $(event.target);

--- a/camptix.js
+++ b/camptix.js
@@ -174,38 +174,37 @@ var docCookies={getItem:function(e){return decodeURIComponent(document.cookie.re
 	 */
 	var lazyLoad = {
 		cache: {
-			$document:  $(document),
-			$attendees: $('#tix-attendees')
+			$document:  $( document ),
+			$attendees: $( '#tix-attendees' )
 		},
 
+        /**
+		 * Initialize placeholders to be lazy-loaded into avatars.
+         */
 		init: function() {
 			// Dependencies
-			if (
-				lazyLoad.cache.$attendees.length < 1
-				||
-				'undefined' == typeof $.fn.appear
-				||
-				'undefined' == typeof wp
-			) {
+			if ( lazyLoad.cache.$attendees.length < 1 ||
+				'undefined' === typeof $.fn.appear ||
+				'undefined' === typeof wp ) {
 				return;
 			}
 
 			var spinner = 'undefined' !== typeof $.fn.spin;
 
-			lazyLoad.avatarTemplate = wp.template('tix-attendee-avatar');
+			lazyLoad.avatarTemplate = wp.template( 'tix-attendee-avatar' );
 
-			lazyLoad.cache.$placeholders = lazyLoad.cache.$attendees.find('.avatar-placeholder');
+			lazyLoad.cache.$placeholders = lazyLoad.cache.$attendees.find( '.avatar-placeholder' );
 
 			lazyLoad.cache.$placeholders.appear({ interval: 500 });
 
-			lazyLoad.cache.$placeholders.one('appear', function(event) {
-				var $placeholder = $(event.target);
+			lazyLoad.cache.$placeholders.one( 'appear', function(event) {
+				var $placeholder = $( event.target );
 
 				$placeholder.each(function() {
-					if (spinner) {
-						$(this).spin('medium');
+					if ( spinner ) {
+						$( this ).spin( 'medium' );
 					}
-					lazyLoad.convertPlaceholder($(this));
+					lazyLoad.convertPlaceholder( $( this ) );
 				});
 			});
 
@@ -213,15 +212,20 @@ var docCookies={getItem:function(e){return decodeURIComponent(document.cookie.re
 			$.force_appear();
 		},
 
-		convertPlaceholder: function($placeholder) {
+        /**
+		 * Replace a placeholder with an instance of the avatar template.
+		 *
+         * @param {Object} $placeholder
+         */
+		convertPlaceholder: function( $placeholder ) {
 			var content = lazyLoad.avatarTemplate( $placeholder.data() );
 
-			if (content) {
-				$placeholder.after(content).remove();
+			if ( content ) {
+				$placeholder.after( content ).remove();
 			}
 		}
 	};
 
-	$(document).ready(lazyLoad.init)
+	$( document ).ready( lazyLoad.init )
 
 }(jQuery));

--- a/camptix.js
+++ b/camptix.js
@@ -179,11 +179,20 @@ var docCookies={getItem:function(e){return decodeURIComponent(document.cookie.re
 		},
 
 		init: function() {
-			if ('undefined' == typeof $.fn.appear || lazyLoad.cache.$attendees.length < 1) {
+			// Dependencies
+			if (
+				lazyLoad.cache.$attendees.length < 1
+				||
+				'undefined' == typeof $.fn.appear
+				||
+				'undefined' == typeof wp
+			) {
 				return;
 			}
 
 			var spinner = 'undefined' !== typeof $.fn.spin;
+
+			lazyLoad.avatarTemplate = wp.template('tix-attendee-avatar');
 
 			lazyLoad.cache.$placeholders = lazyLoad.cache.$attendees.find('.avatar-placeholder');
 
@@ -205,22 +214,11 @@ var docCookies={getItem:function(e){return decodeURIComponent(document.cookie.re
 		},
 
 		convertPlaceholder: function($placeholder) {
-			var hash = $placeholder.data('tix-avatar-hash'),
-				request;
+			var content = lazyLoad.avatarTemplate( $placeholder.data() );
 
-			request = $.post(
-				camptix_l10n.ajaxURL,
-				{
-					action: 'camptix_attendees_load_avatar',
-					'tix-avatar-hash': hash
-				}
-			);
-
-			request.done(function(content) {
-				if (content) {
-					$placeholder.after(content).remove();
-				}
-			});
+			if (content) {
+				$placeholder.after(content).remove();
+			}
 		}
 	};
 


### PR DESCRIPTION
A large attendee list causes a large number of concurrent requests to be sent from the browser to Gravatar, which bogs down the page loading performance.

This inserts a placeholder element for all but the first 50 attendee avatars in a list. A jQuery plugin called [Appear](https://github.com/morr/jquery.appear) (MIT licensed) is used to detect when a placeholder element is about to scroll into view, which triggers an Ajax call to retrieve the actual markup for that attendee's avatar. Jetpack's jquery.spin script is used (if available) to provide a visual indicator that an avatar is in the process of loading.

Refs https://meta.trac.wordpress.org/ticket/1760

cc @iandunn 