### PR TITLE
Allow centralized translation

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -3,6 +3,7 @@
  * Plugin Name: CampTix Event Ticketing
  * Plugin URI:  http://wordcamp.org
  * Description: Simple and flexible event ticketing for WordPress.
+ * Text Domain: camptix
  * Version:     1.5.1
  * Author:      Automattic
  * Author URI:  http://wordcamp.org


### PR DESCRIPTION
As per error on https://wordpress.slack.com/archives/meta-language-packs/p1480781402040387, added the
 * Text Domain: camptix 
so the community can help translating https://translate.wordpress.org/projects/wp-plugins/camptix