### PR TITLE
Mobile Field as Default Addon

### DIFF
--- a/addons/field-mobile.php
+++ b/addons/field-mobile.php
@@ -2,8 +2,8 @@
 /**
  * Mobile Field Addon for CampTix
  *
- * A few of the payment platforms requie the mobile/phone field to complete the
- * transction. By adding it as a field, the payment class can explictly call this
+ * A few of the payment platforms require the mobile/phone field to complete the 
+ * transaction. By adding it as a field, the payment class can explicitly call this 
  * field type to pass the variable to the payment platform.
  *
  */

--- a/addons/field-mobile.php
+++ b/addons/field-mobile.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * Mobile Field Addon for CampTix
@@ -36,7 +35,7 @@ class CampTix_Addon_Mobile_Field extends CampTix_Addon {
 	 */
 	function question_field_mobile( $name, $value ) {
 		?>
-		<input name="<?php echo esc_attr( $name ); ?>" type="url" value="<?php echo esc_attr( $value ); ?>" />
+		<input name="<?php echo esc_attr( $name ); ?>" type="tel" value="<?php echo esc_attr( $value ); ?>" />
 		<?php
 	}
 }

--- a/addons/field-mobile.php
+++ b/addons/field-mobile.php
@@ -1,0 +1,45 @@
+
+<?php
+/**
+ * Mobile Field Addon for CampTix
+ *
+ * A few of the payment platforms requie the mobile/phone field to complete the
+ * transction. By adding it as a field, the payment class can explictly call this
+ * field type to pass the variable to the payment platform.
+ *
+ */
+class CampTix_Addon_Mobile_Field extends CampTix_Addon {
+
+	/**
+	 * Register hook callbacks
+	 */
+	function camptix_init() {
+		add_filter( 'camptix_question_field_types',   array( $this, 'question_field_types'   ) );
+		add_action( 'camptix_question_field_mobile', array( $this, 'question_field_mobile' ), 10, 3 );
+	}
+
+	/**
+	 * Add Country to the list of question types.
+	 *
+	 * @param array $types
+	 *
+	 * @return array
+	 */
+	function question_field_types( $types ) {
+		return array_merge( $types, array(
+			'mobile' => 'Mobile',
+		) );
+	}
+
+	/**
+	 * A url input for a question.
+	 */
+	function question_field_mobile( $name, $value ) {
+		?>
+		<input name="<?php echo esc_attr( $name ); ?>" type="url" value="<?php echo esc_attr( $value ); ?>" />
+		<?php
+	}
+}
+
+// Register this class as a CampTix Addon.
+camptix_register_addon( 'CampTix_Addon_Mobile_Field' );

--- a/addons/field-mobile.php
+++ b/addons/field-mobile.php
@@ -13,7 +13,7 @@ class CampTix_Addon_Mobile_Field extends CampTix_Addon {
 	 * Register hook callbacks
 	 */
 	function camptix_init() {
-		add_filter( 'camptix_question_field_types',   array( $this, 'question_field_types'   ) );
+		add_filter( 'camptix_question_field_types',  array( $this, 'question_field_types'  ) );
 		add_action( 'camptix_question_field_mobile', array( $this, 'question_field_mobile' ), 10, 3 );
 	}
 

--- a/camptix.php
+++ b/camptix.php
@@ -7738,6 +7738,7 @@ class CampTix_Plugin {
 			'field-twitter'  => $this->get_default_addon_path( 'field-twitter.php' ),
 			'field-url'      => $this->get_default_addon_path( 'field-url.php' ),
 			'field-country'  => $this->get_default_addon_path( 'field-country.php' ),
+			'field-mobile'   => $this->get_default_addon_path( 'field-mobile.php' ),
 			'field-tshirt'   => $this->get_default_addon_path( 'field-tshirt.php' ),
 			'shortcodes'     => $this->get_default_addon_path( 'shortcodes.php' ),
 			'payment-paypal' => $this->get_default_addon_path( 'payment-paypal.php' ),


### PR DESCRIPTION
Suggesting to load the mobile filed as a default addon for CampTix, so that there is a common field, whenever required by any associated applications, such as for a Payment Gateway.