### PR TITLE
Include in email option for fields

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -160,6 +160,7 @@ window.camptix = window.camptix || { models: {}, views: {}, collections: {} };
 				question: '',
 				values: '',
 				required: false,
+				include_in_email: false,
 				order: 0,
 				json: ''
 			}
@@ -427,7 +428,8 @@ window.camptix = window.camptix || { models: {}, views: {}, collections: {} };
 					// Make sure post_id and required are correct types, not integers.
 					question.set( {
 						post_id: parseInt( question.get( 'post_id' ), 10 ),
-						required: !! parseInt( question.get( 'required' ), 10 )
+						required: !! parseInt( question.get( 'required' ), 10 ),
+						include_in_email: !! parseInt( question.get( 'include_in_email' ), 10 )
 					}, { silent: true } );
 
 					var found = camptix.questions.where( { post_id: parseInt( question.get( 'post_id' ), 10 ) } );

--- a/camptix.php
+++ b/camptix.php
@@ -7143,7 +7143,36 @@ class CampTix_Plugin {
 		if ( isset( $order['coupon'] ) && $order['coupon'] )
 			$receipt_content .= sprintf( '* ' . __( 'Coupon used: %s', 'camptix' ) . "\n", $order['coupon'] );
 
-		$receipt_content .= sprintf( "* " . __( 'Total: %s', 'camptix' ), $this->append_currency( $order['total'], false ) );
+		$receipt_content .= sprintf( "* " . __( 'Total: %s', 'camptix' )."\n", $this->append_currency( $order['total'], false ) );
+
+		foreach ( $order['items'] as $item ) {
+
+			$question_ids = (array) get_post_meta( $item['id'], 'tix_question_id' );
+			$order = (array) get_post_meta( $item['id'], 'tix_questions_order', true );
+
+			// Make sure we have at least some questions
+			if ( empty( $question_ids ) )
+				return array();
+
+			$questions = get_posts( array(
+				'post_type' => 'tix_question',
+				'post_status' => 'publish',
+				'posts_per_page' => -1,
+				'post__in' => $question_ids,
+			) );
+
+			foreach ( $attendees as $attendee ) {
+				foreach ( $questions as $question ) {
+					// if question is to be included in email
+						// grab the questions name
+						// grab the value from the attendee post meta
+						// append them to receipt content
+				}
+				break;
+			}
+
+		}
+
 		$signature = apply_filters( 'camptix_ticket_email_signature', __( 'Let us know if you have any questions!', 'camptix' ) );
 
 		// Set the tmp receipt for shortcodes use.

--- a/camptix.php
+++ b/camptix.php
@@ -4293,6 +4293,14 @@ class CampTix_Plugin {
 							<label><input data-model-attribute="required" data-model-attribute-type="checkbox" id="tix-add-question-required" type="checkbox" value="1" /> <?php _e( 'This field is required', 'camptix' ); ?></label>
 						</td>
 					</tr>
+					<tr valign="top">
+						<th scope="row">
+							<label><?php _e( 'Include in Email', 'camptix' ); ?></label>
+						</th>
+						<td>
+							<label><input data-model-attribute="include_in_email" data-model-attribute-type="checkbox" id="tix-add-question-required" type="checkbox" value="1" /> <?php _e( 'Include this field in the email confirmation', 'camptix' ); ?></label>
+						</td>
+					</tr>
 				</table>
 				<p class="submit">
 					<a href="#" class="button tix-add"><?php _e( 'Add Question', 'camptix' ); ?></a>


### PR DESCRIPTION
WIP PR

Adds an include in email checkbox

<img width="583" alt="screen shot 2017-08-20 at 15 23 53" src="https://user-images.githubusercontent.com/58855/29495674-b4af5a44-85bb-11e7-9bf2-2c6c761cb181.png">


At the moment it stores and saves ok, the final part is the actual display of the answers of those fields in the email which is incomplete