### PR TITLE
Attendees with the same email are accidentally being hidden in some circumstances.

### DIFF
--- a/addons/shortcodes.php
+++ b/addons/shortcodes.php
@@ -297,6 +297,14 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 
 					$attendees = array();
 					foreach ( $attendees_raw as $attendee ) {
+
+						// Skip attendees marked as private.
+						$privacy = get_post_meta( $attendee, 'tix_privacy', true );
+
+						if ( 'private' === $privacy ) {
+							continue;
+						}
+
 						$email               = get_post_meta( $attendee, 'tix_email', true );
 						$attendees[ $email ] = $attendee;
 					}
@@ -305,13 +313,6 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 						$attendee_answers = (array) get_post_meta( $attendee_id, 'tix_questions', true );
 						if ( $printed >= $attr['posts_per_page'] ) {
 							break;
-						}
-
-						// Skip attendees marked as private.
-						$privacy = get_post_meta( $attendee_id, 'tix_privacy', true );
-						if ( $privacy == 'private' ) {
-							$printed ++;
-							continue;
 						}
 
 						echo '<li>';
@@ -373,12 +374,12 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 		$size = 96;
 
 		return sprintf(
-			'<div 
-                class="avatar avatar-placeholder" 
-                data-url="%s" 
-                data-url2x="%s" 
-                data-size="%s" 
-                data-alt="%s" 
+			'<div
+                class="avatar avatar-placeholder"
+                data-url="%s"
+                data-url2x="%s"
+                data-size="%s"
+                data-alt="%s"
                 data-appear-top-offset="500"
                 ></div>',
 			get_avatar_url( $id_or_email ),


### PR DESCRIPTION
So this just happened on the WordCamp Orlando site, and as a quick workaround changing the emails to be unique will fix things.

Consider this situation:

Father buys a ticket for himself, and his spouse/child/whatever. And all tickets are registered with the same email address. Because of how CampTix works, only one attendee will be displayed and it's the one that's last in the alphabetical order.

Now say you hide just that attendee from display on the attendees page. Any other attendees with the same email will now _also be hidden_.

In our situation we had an entire family with the same email address with the following names:
Emma (child)
Iris (mother)
James (father)
Jamie (child)
Mayah (child)

Only Mayah was being displayed on the attendee page and this needed to be changed to display James. Additionally, Iris also needed to be displayed. My thought was to hide all the children (check the "Hide from public attendees list" checkbox) and change the email address on Iris. This led to only Iris being displayed, due to the simple fact that James was being "overwritten" by first Jamie and then Mayah, who are both set to be hidden.

This PR will move the check for the `tix_privacy` field up and it will skip trying to add their name to the `$attendee` array altogether. That way we'd still only display unique emails on the attendee page as before, but they won't be affected by any attendees with the same email that are set to be hidden.

The simplified test case on my local looks like this, with Mayah set to be hidden:

![test-case](https://user-images.githubusercontent.com/1461585/31593287-bc920b3c-b1fb-11e7-8492-25ed97c5611d.png)

The front-end displays both Iris and James, as expected:

![result](https://user-images.githubusercontent.com/1461585/31593307-d98a1842-b1fb-11e7-8326-1b99b06db59f.png)

It also looks like my editor stripped some spaces at the end of some lines. It doesn't look like this has had any effect on the front end, but can be fixed if it's an issue to merge in.