### PR TITLE
Allow wrapping subpages

### DIFF
--- a/addons/shortcodes.php
+++ b/addons/shortcodes.php
@@ -598,12 +598,12 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 			if ( isset( $_POST['tix_private_shortcode_submit'] ) )
 				$camptix->info( __( 'Success! Enjoy your content!', 'camptix' ) );
 
-			return $this->shortcode_private_display_content( $atts, $content );
+			return $this->shortcode_private_display_content( $args, $content );
 		} else {
 			if ( ! isset( $_POST['tix_private_shortcode_submit'] ) && ! $error )
 				$camptix->notice( __( 'The content on this page is private. Please log in using the form below.', 'camptix' ) );
 
-			return $this->shortcode_private_login_form( $atts, $content );
+			return $this->shortcode_private_login_form( $args, $content );
 		}
 	}
 

--- a/camptix.php
+++ b/camptix.php
@@ -5238,9 +5238,9 @@ class CampTix_Plugin {
 							?>
 							<tr class="tix-ticket-<?php echo absint( $ticket->ID ); ?>">
 								<td class="tix-column-description">
-									<strong class="tix-ticket-title"><?php echo esc_html( $ticket->post_title ); ?></strong>
+									<strong class="tix-ticket-title"><?php echo wp_kses_post( $ticket->post_title ); ?></strong>
 									<?php if ( $ticket->post_excerpt ) : ?>
-										<br /><span class="tix-ticket-excerpt"><?php echo esc_html( $ticket->post_excerpt ); ?></span>
+										<br /><span class="tix-ticket-excerpt"><?php echo wp_kses_post( $ticket->post_excerpt ); ?></span>
 									<?php endif; ?>
 									<?php if ( $ticket->tix_coupon_applied ) : ?>
 										<br /><small class="tix-discount"><?php echo esc_html( $ticket->tix_discounted_text ); ?></small>

--- a/camptix.php
+++ b/camptix.php
@@ -5128,7 +5128,6 @@ class CampTix_Plugin {
 	 * Step 1: shows the available tickets table.
 	 */
 	function form_start() {
-        // add_action('wp_enqueue_scripts', function() { error_log('wait'); wp_localize_script( 'camptix', 'camptix_fb', [ 'eli' => 'testing' ] ); }, 11);
 		$available_tickets = 0;
 		$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order', 10 );
 
@@ -5553,18 +5552,12 @@ class CampTix_Plugin {
 
 				<p class="tix-submit">
 					<?php if ( $total > 0 ) : ?>
-					    <?php if ( !empty($this->options['checkout_buttons']) ) : ?>
-                            <?php foreach ( $this->get_enabled_payment_methods() as $payment_method_key => $payment_method ) : ?>
-                                <button id="tix-pm-<?php echo esc_attr( $payment_method_key ); ?>" type="submit" name="tix_payment_method" value="<?php echo esc_attr( $payment_method_key ); ?>"><?php esc_attr_e( 'Checkout with', 'camptix' ); ?> <?php echo esc_html( $payment_method['name'] ); ?></button>
+                        <select name="tix_payment_method">
+    						<?php foreach ( $this->get_enabled_payment_methods() as $payment_method_key => $payment_method ) : ?>
+    							<option <?php selected( ! empty( $this->form_data['tix_payment_method'] ) && $this->form_data['tix_payment_method'] == $payment_method_key ); ?> value="<?php echo esc_attr( $payment_method_key ); ?>"><?php echo esc_html( $payment_method['name'] ); ?></option>
     						<?php endforeach; ?>
-    					<?php else : ?>
-                            <select name="tix_payment_method">
-        						<?php foreach ( $this->get_enabled_payment_methods() as $payment_method_key => $payment_method ) : ?>
-        							<option <?php selected( ! empty( $this->form_data['tix_payment_method'] ) && $this->form_data['tix_payment_method'] == $payment_method_key ); ?> value="<?php echo esc_attr( $payment_method_key ); ?>"><?php echo esc_html( $payment_method['name'] ); ?></option>
-        						<?php endforeach; ?>
-        					</select>
-        					<input type="submit" value="<?php esc_attr_e( 'Checkout &rarr;', 'camptix' ); ?>" />
-					    <?php endif; ?>
+    					</select>
+    					<input type="submit" value="<?php esc_attr_e( 'Checkout &rarr;', 'camptix' ); ?>" />
 					<?php else : ?>
 						<input type="submit" value="<?php esc_attr_e( 'Claim Tickets &rarr;', 'camptix' ); ?>" />
 					<?php endif; ?>

--- a/camptix.php
+++ b/camptix.php
@@ -1157,6 +1157,7 @@ class CampTix_Plugin {
 			'version' => 0,
 			'reservations_enabled' => false,
 			'refunds_enabled' => false,
+			'wrap_subpages' => false,
 			'refund_all_enabled' => false,
 			'archived' => false,
 			'payment_methods' => array(),
@@ -1496,6 +1497,9 @@ class CampTix_Plugin {
 					__( "This will allows your customers to refund their tickets purchase by filling out a simple refund form.", 'camptix' )
 				);
 
+				$this->add_settings_field_helper( 'wrap_subpages', __( 'Wrap Subpages', 'camptix' ), 'field_yesno', false,
+				    __( "Setting this to yes will cause all additional pages of content created by the shortcode to still have the rest of the page content on it, otherwise it will be stripped for cleaner output.", 'camptix' )
+				);
 				break;
 			case 'payment':
 				foreach ( $this->get_available_payment_methods() as $key => $payment_method ) {
@@ -1621,7 +1625,7 @@ class CampTix_Plugin {
 		if ( isset( $input['refunds_date_end'], $input['refunds_enabled'] ) && (bool) $input['refunds_enabled'] && strtotime( $input['refunds_date_end'] ) )
 			$output['refunds_date_end'] = $input['refunds_date_end'];
 
-		$yesno_fields = array( 'refunds_enabled' );
+		$yesno_fields = array( 'refunds_enabled', 'wrap_subpages' );
 
 		// Beta features checkboxes
 		if ( $this->beta_features_enabled )
@@ -5124,6 +5128,7 @@ class CampTix_Plugin {
 	 * Step 1: shows the available tickets table.
 	 */
 	function form_start() {
+        // add_action('wp_enqueue_scripts', function() { error_log('wait'); wp_localize_script( 'camptix', 'camptix_fb', [ 'eli' => 'testing' ] ); }, 11);
 		$available_tickets = 0;
 		$max_tickets_per_order = apply_filters( 'camptix_max_tickets_per_order', 10 );
 
@@ -5326,7 +5331,9 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		if ( empty( $this->options['wrap_subpages'] ) ) {
+    		$post->post_content = $this->shortcode_str;
+		}  
 
 		if ( isset( $this->error_flags['no_tickets_selected'], $_GET['tix_action'] ) && 'checkout' == $_GET['tix_action'] )
 			return $this->form_start();
@@ -5572,7 +5579,9 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		if ( empty( $this->options['wrap_subpages'] ) ) {
+    		$post->post_content = $this->shortcode_str;
+		}  
 
 		ob_start();
 
@@ -5710,7 +5719,9 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		if ( empty( $this->options['wrap_subpages'] ) ) {
+    		$post->post_content = $this->shortcode_str;
+		}  
 
 		ob_start();
 		if ( ! isset( $_REQUEST['tix_edit_token'] ) || empty( $_REQUEST['tix_edit_token'] ) || ! ctype_alnum( $_REQUEST['tix_edit_token'] ) ) {
@@ -5891,7 +5902,9 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		if ( empty( $this->options['wrap_subpages'] ) ) {
+    		$post->post_content = $this->shortcode_str;
+		}  
 
 		if ( ! $this->options['refunds_enabled'] || ! isset( $_REQUEST['tix_access_token'] ) || ! ctype_alnum( $_REQUEST['tix_access_token'] ) ) {
 			$this->error_flags['invalid_access_token'] = true;
@@ -6066,7 +6079,9 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		if ( empty( $this->options['wrap_subpages'] ) ) {
+    		$post->post_content = $this->shortcode_str;
+		}  
 
 		ob_start();
 		?>
@@ -6483,7 +6498,9 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		if ( empty( $this->options['wrap_subpages'] ) ) {
+    		$post->post_content = $this->shortcode_str;
+		}  
 
 		$attendees = array();
 		$errors = array();


### PR DESCRIPTION
I've added a new option to the settings for whether people want the subpages (checkout screen, attendee screen, etc) to have the template blown away like the original code did.  Or whether you still want the output wrapped in the standard template/page that otherwise this checkout existed in.