### PR TITLE
E-mail Templates options screen: Show first & last name shortcodes

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -1626,7 +1626,7 @@ class CampTix_Plugin {
 		<p><?php _e( 'Customize your confirmation e-mail templates.', 'camptix' ); ?></p>
 
 		<p>
-			<?php _e( 'You can use the following shortcodes inside the message: [event_name], [ticket_url], [receipt], and [buyer_full_name].', 'camptix' ); ?>
+			<?php _e( 'You can use the following shortcodes inside the message: [event_name], [ticket_url], [receipt], [buyer_full_name], [last_name], and [first_name].', 'camptix' ); ?>
 		</p>
 
 		<?php if ( self::html_mail_enabled() ) : ?>


### PR DESCRIPTION
Show `[last_name]` and `[first_name]` in addition to `[buyer_full_name]` to accomodate for languages with family name -> given name order.

`[buyer_full_name]` isn't ideal for languages like Japanese, Chinese, Korean, and Vietnamese where the family name is placed in front of the given name.

@mayukojpn pointed out that `[last_name]` and `[first_name]` should also work. We tested this and it worked fine.

Why not expose last & first name options on Tickets > Set up > E-mail Templates page?

<img width="621" alt="camptix-e-mail-templates" src="https://user-images.githubusercontent.com/34067/43290739-fe3b0ba8-9169-11e8-87b8-55c64723ccb8.png">
