### PR TITLE
New hooks for programmers

### DIFF
--- a/addons/payment-paypal.php
+++ b/addons/payment-paypal.php
@@ -639,7 +639,7 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 			'tix_payment_method' => 'paypal',
 		), $camptix->get_tickets_url() );
 
-		$payload = array(
+		$payload = apply_filters( 'camptix_paypal_payload', array(
 			'METHOD'                                => 'SetExpressCheckout',
 			'PAYMENTREQUEST_0_PAYMENTACTION'        => 'Sale',
 			'PAYMENTREQUEST_0_ALLOWEDPAYMENTMETHOD' => 'InstantPaymentOnly', // @todo allow echecks with an option
@@ -648,7 +648,7 @@ class CampTix_Payment_Method_PayPal extends CampTix_Payment_Method {
 			'ALLOWNOTE'                             => 0,
 			'NOSHIPPING'                            => 1,
 			'SOLUTIONTYPE'                          => 'Sole',
-		);
+		));
 
 		// See https://developer.paypal.com/webapps/developer/docs/classic/api/merchant/SetExpressCheckout_API_Operation_NVP/
 		$locale_code = _x( 'default', 'PayPal locale code, leave default to guess', 'camptix' );

--- a/camptix.php
+++ b/camptix.php
@@ -5407,7 +5407,7 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		$post->post_content = apply_filters( 'camptix_post_content_override', $this->shortcode_str, $post->post_content, $_GET['tix_action'] );
 
 		if ( isset( $this->error_flags['no_tickets_selected'], $_GET['tix_action'] ) && 'checkout' == $_GET['tix_action'] )
 			return $this->form_start();
@@ -5678,7 +5678,7 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		$post->post_content = apply_filters( 'camptix_post_content_override', $this->shortcode_str, $post->post_content, $_GET['tix_action'] );
 
 		ob_start();
 
@@ -5816,7 +5816,7 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		$post->post_content = apply_filters( 'camptix_post_content_override', $this->shortcode_str, $post->post_content, $_GET['tix_action'] );
 
 		ob_start();
 		if ( ! isset( $_REQUEST['tix_edit_token'] ) || empty( $_REQUEST['tix_edit_token'] ) || ! ctype_alnum( $_REQUEST['tix_edit_token'] ) ) {
@@ -6002,7 +6002,7 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		$post->post_content = apply_filters( 'camptix_post_content_override', $this->shortcode_str, $post->post_content, $_GET['tix_action'] );
 
 		if ( ! $this->options['refunds_enabled'] || ! isset( $_REQUEST['tix_access_token'] ) || ! ctype_alnum( $_REQUEST['tix_access_token'] ) ) {
 			$this->error_flags['invalid_access_token'] = true;
@@ -6177,7 +6177,7 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		$post->post_content = apply_filters( 'camptix_post_content_override', $this->shortcode_str, $post->post_content, $_GET['tix_action'] );
 
 		ob_start();
 		?>
@@ -6594,7 +6594,7 @@ class CampTix_Plugin {
 		global $post;
 
 		// Clean things up before and after the shortcode.
-		$post->post_content = $this->shortcode_str;
+		$post->post_content = apply_filters( 'camptix_post_content_override', $this->shortcode_str, $post->post_content, $_GET['tix_action'] );
 
 		$attendees = array();
 		$errors = array();


### PR DESCRIPTION
This includes what I originally had sent PRs for under #199 and #201 ... but now the 'right way'.

Basically, I'd submitted originally a couple of feature enhancements, that give you controls to do the following two things:

1. Control whether camptix removed all page content before & after the [camptix] shortcode, which it does by default on any subpage.
2. Control some additional paypal checkout configuration, such as whether to ask for a shipping address.

The #1 feedback I got from @coreymckrill was that the camptix team would prefer to add hooks into camptix, to allow such features to exist in plugins.   Rather than complicate the base camptix install with more and more features.

Makes sense!

So this PR adds in the missing hooks that didn't allow these two features to exist in a plugin.  

It adds a filter, that gets the post_content and shortcode_str, and by default does what camptix always does... but now allows a programmer to change anything about the output there.

And it adds a configuration filter to the paypal payload, allowing you to change or add any paypal configuration features that aren't normally within your control via the UI.