### PR TITLE
Camptix Stripe bug-fix (.unique() vs .uniqueSort())

### DIFF
--- a/camptix.js
+++ b/camptix.js
@@ -297,7 +297,7 @@ var CampTixStripe = new function() {
 	};
 
 	self.stripe_checkout = function() {
-		var emails = jQuery.uniqueSort(
+		var emails = jQuery.unique(
 			self.form.find('input[type="email"]')
 				.filter( function () { return this.value.length; })
 				.map( function() { return this.value; } )


### PR DESCRIPTION
This was a PR I'd submitted to the original stripe plugin, but never got accepted there before the code was merged here into the main camptix:

The Stripe plugin uses jQuery.uniqueSort(), however, that function only exists in jQuery 3.x which many themes and even WordPress itself doesn't use or include.  Changing this to just .unique() which is aliased in 3.x and works in 2.x as well for greater compatibility.   Otherwise lots of people will end up getting failures when trying to use Stripe.