### PR TITLE
Memoize buyer data to save SQL queries to figure out ticket buyer of …

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -2930,6 +2930,11 @@ class CampTix_Plugin {
 
 			$escaped_field = '';
 
+			$first_char = $field[0];
+			if ( in_array( $first_char, $delimiters ) ) {
+				$escaped_field .= "'";
+			}
+
 			// Escape trigger characters that follow delimiters, or are at the start
 			$is_prev_char_delimiter = true;
 			for ( $i = 0; $i < strlen( $field ); $i++ ) {

--- a/camptix.php
+++ b/camptix.php
@@ -2813,7 +2813,6 @@ class CampTix_Plugin {
 			unset( $attendee_ids, $attendee );
 			$buyer_map = array();
 
-
 			foreach ( $attendees as $attendee ) {
 				$attendee_id = $attendee->ID;
 
@@ -2934,23 +2933,26 @@ class CampTix_Plugin {
 		);
 
 		foreach( $fields as $index => $field ) {
-			// Escape trigger characters at the start of a new field
-			$first_cell_character = mb_substr( $field, 0, 1 );
-			$is_trigger_character = in_array( $first_cell_character, $active_content_triggers, true );
-			$is_delimiter         = in_array( $first_cell_character, $delimiters,              true );
 
-			if ( $is_trigger_character || $is_delimiter ) {
-				$field = "'" . $field;
+			if ( ! is_string( $field ) ) {
+				continue;
 			}
 
-			// Escape trigger characters that follow delimiters
-			foreach ( $delimiters as $delimiter ) {
-				foreach ( $active_content_triggers as $trigger ) {
-					$field = str_replace( $delimiter . $trigger, $delimiter . "'" . $trigger, $field );
+			$escaped_field = '';
+
+			// Escape trigger characters that follow delimiters, or are at the start
+			$is_prev_char_delimiter = true;
+			for ( $i = 0; $i < strlen( $field ); $i++ ) {
+				$char = $field[ $i ];
+				if ( $is_prev_char_delimiter && in_array( $char, $active_content_triggers ) ) {
+					$escaped_field .= "'";
 				}
+				$escaped_field .= $char;
+				$is_prev_char_delimiter = in_array( $char, $delimiters );
 			}
 
-			$fields[ $index ] = $field;
+			$fields[ $index ] = $escaped_field;
+
 		}
 
 		return $fields;

--- a/camptix.php
+++ b/camptix.php
@@ -2808,11 +2808,11 @@ class CampTix_Plugin {
 
 				$access_token = get_post_meta( $attendee->ID, 'tix_access_token', true );
 
-				/**
+				/*
 				 So when a buyer buys tickets for a bunch of attendees, access token for all those attendees would be same.
 				 Further, the buyer will always be inserted first into the database.
 				 Which means that when access token for a lot attendees is same, we can figure out the buyer by finding the first attendee with same access token.
-				 * **/
+				 */
 				if ( ! isset( $buyer_map[ $access_token ] ) ) {
 					$buyer_map[ $access_token ] = $attendee->post_title;
 				}
@@ -2933,12 +2933,12 @@ class CampTix_Plugin {
 			// Escape trigger characters that follow delimiters, or are at the start
 			$is_prev_char_delimiter = true;
 			for ( $i = 0; $i < strlen( $field ); $i++ ) {
-				$char = $field[ $i ];
-				if ( $is_prev_char_delimiter && in_array( $char, $active_content_triggers ) ) {
+				$current_char = $field[ $i ];
+				if ( $is_prev_char_delimiter && in_array( $current_char, $active_content_triggers ) ) {
 					$escaped_field .= "'";
 				}
-				$escaped_field .= $char;
-				$is_prev_char_delimiter = in_array( $char, $delimiters );
+				$escaped_field .= $current_char;
+				$is_prev_char_delimiter = in_array( $current_char, $delimiters );
 			}
 
 			$fields[ $index ] = $escaped_field;
@@ -6584,7 +6584,6 @@ class CampTix_Plugin {
 	 * Step 3: Uses a payment method to perform a checkout.
 	 */
 	function form_checkout() {
-
 		global $post;
 
 		// Clean things up before and after the shortcode.

--- a/camptix.php
+++ b/camptix.php
@@ -2791,27 +2791,17 @@ class CampTix_Plugin {
 			$report = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL . '<attendees>' . PHP_EOL;
 
 		$paged = 1;
+		$buyer_map = array();
 
 		// Ordering by ID ASC is important. Presence of buyer row depends on it. Buyer has to fetched, same or before rest of attendees rows are fetched.
 		while ( $attendees = get_posts( array(
 			'post_type' => 'tix_attendee',
 			'post_status' => array( 'publish', 'pending' ),
-			'posts_per_page' => 200,
+			'posts_per_page' => 500,
 			'paged' => $paged++,
 			'orderby' => 'ID',
 			'order' => 'ASC',
-			'cache_results' => false,
 		) ) ) {
-			$attendee_ids = array();
-			foreach ( $attendees as $attendee )
-				$attendee_ids[] = $attendee->ID;
-
-			/**
-			 * Magic here, to by-pass object caching. See Revenue report for more info.
-			 */
-			$this->filter_post_meta = $this->prepare_metadata_for( $attendee_ids );
-			unset( $attendee_ids, $attendee );
-			$buyer_map = array();
 
 			foreach ( $attendees as $attendee ) {
 				$attendee_id = $attendee->ID;

--- a/camptix.php
+++ b/camptix.php
@@ -2924,7 +2924,7 @@ class CampTix_Plugin {
 
 		foreach( $fields as $index => $field ) {
 
-			if ( ! is_string( $field ) ) {
+			if ( is_numeric( $field ) ) {
 				continue;
 			}
 

--- a/camptix.php
+++ b/camptix.php
@@ -2930,7 +2930,7 @@ class CampTix_Plugin {
 
 			$escaped_field = '';
 
-			$first_char = $field[0];
+			$first_char = mb_substr( $field, 0, 1 );
 			if ( in_array( $first_char, $delimiters ) ) {
 				$escaped_field .= "'";
 			}

--- a/camptix.php
+++ b/camptix.php
@@ -2937,8 +2937,8 @@ class CampTix_Plugin {
 
 			// Escape trigger characters that follow delimiters, or are at the start
 			$is_prev_char_delimiter = true;
-			for ( $i = 0; $i < strlen( $field ); $i++ ) {
-				$current_char = $field[ $i ];
+			for ( $i = 0; $i < mb_strlen( $field ); $i++ ) {
+				$current_char = mb_substr( $field, $i, 1 );
 				if ( $is_prev_char_delimiter && in_array( $current_char, $active_content_triggers ) ) {
 					$escaped_field .= "'";
 				}

--- a/camptix.php
+++ b/camptix.php
@@ -2830,7 +2830,7 @@ class CampTix_Plugin {
 					'status' => ucfirst( $attendee->post_status ),
 					'txn_id' => get_post_meta( $attendee_id, 'tix_transaction_id', true ),
 					'coupon' => get_post_meta( $attendee_id, 'tix_coupon', true ),
-					'buyer_name' => empty( $buyer ) ? '' : $buyer,
+					'buyer_name' => $buyer,
 					'buyer_email' => get_post_meta( $attendee_id, 'tix_receipt_email', true ),
 					'payment_method' => $this->get_payment_method_name_by_attendee_id( $attendee_id ),
 				);

--- a/tests/test-camptix.php
+++ b/tests/test-camptix.php
@@ -41,13 +41,13 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 			'\'@HYPERLINK("http://malicious.example.org/wp-login.php","Please log back in to your account for more.")',
 			"'-2+3+cmd|' /C mstsc'!A0",
 			"'+2+3+cmd|' /C mspaint'!A0",
-			"';2+3+cmd|' /C calc'!A0",
+			";2+3+cmd|' /C calc'!A0",
 
 			// Cells split by delimiters
 			"foo ;'=cmd|' /C SoundRecorder'!A0",
 			"foo\n'-2+3+cmd|' /C explorer'!A0",
-			"'   '-2+3+cmd|' /C notepad'!A0",
-			"' '-2+3+cmd|' /C calc'!A0",
+			"   '-2+3+cmd|' /C notepad'!A0",
+			" '-2+3+cmd|' /C calc'!A0",
 
 			//mb_tests
 			"漢字はユニコ",

--- a/tests/test-camptix.php
+++ b/tests/test-camptix.php
@@ -41,13 +41,13 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 			'\'@HYPERLINK("http://malicious.example.org/wp-login.php","Please log back in to your account for more.")',
 			"'-2+3+cmd|' /C mstsc'!A0",
 			"'+2+3+cmd|' /C mspaint'!A0",
-			";2+3+cmd|' /C calc'!A0",
+			"';2+3+cmd|' /C calc'!A0",
 
 			// Cells split by delimiters
 			"foo ;'=cmd|' /C SoundRecorder'!A0",
 			"foo\n'-2+3+cmd|' /C explorer'!A0",
-			"   '-2+3+cmd|' /C notepad'!A0",
-			" '-2+3+cmd|' /C calc'!A0",
+			"'   '-2+3+cmd|' /C notepad'!A0",
+			"' '-2+3+cmd|' /C calc'!A0",
 
 			//mb_tests
 			"漢字はユニコ",

--- a/tests/test-camptix.php
+++ b/tests/test-camptix.php
@@ -26,6 +26,10 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 			"foo\n-2+3+cmd|' /C explorer'!A0",
 			"   -2+3+cmd|' /C notepad'!A0",
 			" -2+3+cmd|' /C calc'!A0",
+
+			//mb tests
+			"漢字はユニコ",
+			"-漢字はユニコ ;=æ",
 		);
 
 		$expected_output = array(
@@ -44,6 +48,10 @@ class Test_CampTix_Plugin extends \WP_UnitTestCase {
 			"foo\n'-2+3+cmd|' /C explorer'!A0",
 			"'   '-2+3+cmd|' /C notepad'!A0",
 			"' '-2+3+cmd|' /C calc'!A0",
+
+			//mb_tests
+			"漢字はユニコ",
+			"'-漢字はユニコ ;'=æ",
 		);
 
 		$this->assertEquals( $expected_output, CampTix_Plugin::esc_csv( $test_input ) );


### PR DESCRIPTION
…an attendee.

Attendee data export was timing out for 2018.us.wordcamp.org. Apparently the bottleneck was figuring out the buyer data. We were making meta queries to figure out the attendee buyer data resulting in an `n+1` query pattern. Given how we insert buyer data, we can just treat first attendee with a different access_token, to be the ticker buyer for rest of the attendees of with the same access token.