### PR TITLE
Make URLs in ticket form field labels clickable.

### DIFF
--- a/camptix.php
+++ b/camptix.php
@@ -5609,7 +5609,7 @@ class CampTix_Plugin {
 
 										<tr class="<?php echo esc_attr( $class_name ); ?>">
 											<td class="<?php if ( $required ) echo 'tix-required'; ?> tix-left">
-												<?php echo esc_html( apply_filters( 'the_title', $question->post_title ) ); ?>
+												<?php echo make_clickable( esc_html( apply_filters( 'the_title', $question->post_title ) ) ); ?>
 												<?php if ( $required ) echo ' <span class="tix-required-star">*</span>'; ?>
 											</td>
 											<td class="tix-right">


### PR DESCRIPTION
It seems that we have some special labels on WordCamp sites that include links (like the "learn more" link for being included on the attendees page, which links to https://wordpress.org/about/privacy/). I don't know exactly where that one comes from, but events can't do this themselves because we `esc_html()` those elements. If we at least run that label through `make_clickable()` then they can include URLs for getting more information. You can see a good example of needing this on the [WCUS 2019 Ticket Page](https://2019.us.wordcamp.org/tickets/) where we try to link people to more information about the various contributor teams.

Honestly more HTML there would be awesome, but `make_clickable()` seems like a safe and simple workaround for now.